### PR TITLE
UE5 - ProjectVersionFromGitBPLibrary.h - LNK2019 Fix - add PROJECTVERSIONFROMGIT_API to class declaration

### DIFF
--- a/Source/ProjectVersionFromGit/Public/ProjectVersionFromGitBPLibrary.h
+++ b/Source/ProjectVersionFromGit/Public/ProjectVersionFromGitBPLibrary.h
@@ -19,7 +19,7 @@
 DECLARE_DYNAMIC_DELEGATE(FParseVersionDelegate);
 
 UCLASS()
-class UProjectVersionFromGitBPLibrary : public UBlueprintFunctionLibrary
+class PROJECTVERSIONFROMGIT_API UProjectVersionFromGitBPLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
- Without macro 'PROJECTVERSIONFROMGIT_API' in ProjectVersionFromGitBPLibrary class declaration, VisualStudio will throw LNK2019 linker error if any static method from plugin was called inside of other C++ class. (https://github.com/mrbindraw/ProjectVersionFromGit/issues/2)
- This PR fixes this issue for UE5
- This macro should only be inside of UE5 plugin version. It will mess version for UE4