### PR TITLE
Improved RegEx for version parser

### DIFF
--- a/Source/ProjectVersionFromGit/Private/ProjectVersionFromGitBPLibrary.cpp
+++ b/Source/ProjectVersionFromGit/Private/ProjectVersionFromGitBPLibrary.cpp
@@ -84,7 +84,7 @@ void UProjectVersionFromGitBPLibrary::GetProjectVersionInfo(FParseVersionDelegat
 			OutStdOut.TrimStartAndEndInline();
 			//UE_LOG(LogProjectVersionFromGitBPLibrary, Log, TEXT("-------- Git tag: %s"), *OutStdOut);
 
-			const FRegexPattern myPattern(TEXT("([0-9]\\.[0-9]\\.[0-9])+"));
+			const FRegexPattern myPattern(TEXT("([0-9]+\\.[0-9]+\\.[0-9]+)+"));
 			FRegexMatcher myMatcher(myPattern, OutStdOut);
 
 			if (myMatcher.FindNext())


### PR DESCRIPTION
This change to the RegEx pattern will allow for versions like "1.0.10" to be properly parsed as Major=1, Minor=0 and Patch=10, instead of  Major=1, Minor=0 and Patch=1.