### PR TITLE
Getting latest tag on current branch

### DIFF
--- a/Source/ProjectVersionFromGit/Private/ProjectVersionFromGitBPLibrary.cpp
+++ b/Source/ProjectVersionFromGit/Private/ProjectVersionFromGitBPLibrary.cpp
@@ -76,11 +76,7 @@ void UProjectVersionFromGitBPLibrary::GetProjectVersionInfo(FParseVersionDelegat
 
 			UE_LOG(LogProjectVersionFromGitBPLibrary, Log, TEXT("-------- Cfg->GitBinPath: %s"), *Cfg->GitBinPath);
 
-			ExecProcess(*Cfg->GitBinPath, TEXT("rev-list --tags --max-count=1"), &OutReturnCode, &OutStdOut, &OutStdErr, *OptionalWorkingDirectory);
-			OutStdOut.TrimStartAndEndInline();
-
-			TagNameArg = FString(TEXT("describe --tags ")) + OutStdOut;
-			ExecProcess(*Cfg->GitBinPath, *TagNameArg, &OutReturnCode, &OutStdOut, &OutStdErr, *OptionalWorkingDirectory);
+			ExecProcess(*Cfg->GitBinPath, TEXT("describe --tags --abbrev=0"), &OutReturnCode, &OutStdOut, &OutStdErr, *OptionalWorkingDirectory);
 			OutStdOut.TrimStartAndEndInline();
 			//UE_LOG(LogProjectVersionFromGitBPLibrary, Log, TEXT("-------- Git tag: %s"), *OutStdOut);
 


### PR DESCRIPTION
By using "describe --tags --abbrev=0" instead of the old method, we will get the latest tag on the current branch only. The old way was getting latest tall from the entire repo.
<pre>
Before changes:
main---commit1+tag1---commit+tag2            -> Lastes tag is tag2
                |---commit2                  -> Lastes tag is tag2

After changes
main---commit1+tag1---commit+tag2            -> Lastes tag is tag2
                |---commit2                  -> Lastes tag is tag1
</pre>